### PR TITLE
Fix indentation and commenting

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -4,11 +4,11 @@
 	site_code = 'ffnord',
 
 	opkg = {
-   		openwrt = 'http://[2a03:2267:4e6f:7264::fd02]/%n/%v/%S/packages'
-  		extra = {
-    			modules = 'http://[2a03:2267:4e6f:7264::fd02]/modules/gluon-%GS-%GR/%S',
-  		},
-  	},
+		openwrt = 'http://[2a03:2267:4e6f:7264::fd02]/%n/%v/%S/packages'
+		extra = {
+			modules = 'http://[2a03:2267:4e6f:7264::fd02]/modules/gluon-%GS-%GR/%S',
+		},
+	},
 
 	prefix4 = '10.187.0.0/16',
 	prefix6 = '2a03:2267:4e6f:7264::/64',
@@ -20,17 +20,17 @@
 			'2a03:2267:4e6f:7264::fd02',
 			'2a03:2267:4e6f:7264::fd03',
 			'2a03:2267:4e6f:7264::fd04',
-      			'2a03:2267:4e6f:7264::fd05',
-      			'2a03:2267:4e6f:7264::fd06',
-      			'2a03:2267:4e6f:7264::fd07',
-      			'2a03:2267:4e6f:7264::fd08',
-      			'2a03:2267:4e6f:7264::fd09',
-      			'2a03:2267:4e6f:7264::fd10',
-      			'2a03:2267:4e6f:7264::fd11',
-      			'2a03:2267:4e6f:7264::fd12',
-      			'2a03:2267:4e6f:7264::fd13',
-      			'2a03:2267:4e6f:7264::fd14',
-      			'2a03:2267:4e6f:7264::fd15',
+			'2a03:2267:4e6f:7264::fd05',
+			'2a03:2267:4e6f:7264::fd06',
+			'2a03:2267:4e6f:7264::fd07',
+			'2a03:2267:4e6f:7264::fd08',
+			'2a03:2267:4e6f:7264::fd09',
+			'2a03:2267:4e6f:7264::fd10',
+			'2a03:2267:4e6f:7264::fd11',
+			'2a03:2267:4e6f:7264::fd12',
+			'2a03:2267:4e6f:7264::fd13',
+			'2a03:2267:4e6f:7264::fd14',
+			'2a03:2267:4e6f:7264::fd15',
 	},
 	regdom = 'DE',
 
@@ -113,44 +113,44 @@
 						remotes = {'ipv4 "vpn7.ffnord.net" port 10050', 'ipv6 "vpn7.ffnord.net" port 10050'},
 					},
 					ffnord_vpn8 = {
-            					key = '9d6bf926071340171cc8a692c9a858e482a4368856dcb63e095e393049b8d6fd',
-        					remotes = {'ipv4 "vpn8.ffnord.net" port 10050', 'ipv6 "vpn8.ffnord.net" port 10050'},
-          				},
+						key = '9d6bf926071340171cc8a692c9a858e482a4368856dcb63e095e393049b8d6fd',
+						remotes = {'ipv4 "vpn8.ffnord.net" port 10050', 'ipv6 "vpn8.ffnord.net" port 10050'},
+					},
 					ffnord_vpn9 = {
-            					key = '3b09482cee91e08839c1bfcca5a1135583c03817b1e8ff52019902faef7e2f28',
-            					remotes = {'ipv4 "vpn9.ffnord.net" port 10050', 'ipv6 "vpn9.ffnord.net" port 10050'},
-          				},
+						key = '3b09482cee91e08839c1bfcca5a1135583c03817b1e8ff52019902faef7e2f28',
+						remotes = {'ipv4 "vpn9.ffnord.net" port 10050', 'ipv6 "vpn9.ffnord.net" port 10050'},
+					},
 					ffnord_vpn10 = {
-            					key = 'a326197364109a3a7bfc9344e19da9277734989bc06d930617e00206feb6a065',
-            					remotes = {'ipv4 "vpn10.ffnord.net" port 10050', 'ipv6 "vpn10.ffnord.net" port 10050'},
-          				},
+						key = 'a326197364109a3a7bfc9344e19da9277734989bc06d930617e00206feb6a065',
+						remotes = {'ipv4 "vpn10.ffnord.net" port 10050', 'ipv6 "vpn10.ffnord.net" port 10050'},
+					},
 					ffnord_vpn11 = {
-            					key = '9ab17517450a52d1eac521a6ae4e696cf7861c3e55cd63acf0a94e85cb3e5172',
-            					remotes = {'ipv4 "vpn11.ffnord.net" port 10050', 'ipv6 "vpn11.ffnord.net" port 10050'},
-          				},
+						key = '9ab17517450a52d1eac521a6ae4e696cf7861c3e55cd63acf0a94e85cb3e5172',
+						remotes = {'ipv4 "vpn11.ffnord.net" port 10050', 'ipv6 "vpn11.ffnord.net" port 10050'},
+					},
 					ffnord_vpn12 = {
-            					key = 'bec4e95be17044ead0e1926b58cafc0d2cca9df3eb7a836234e886f3b51679f9',
-            					remotes = {'ipv4 "vpn12.ffnord.net" port 10050', 'ipv6 "vpn12.ffnord.net" port 10050'},
-          				},
+						key = 'bec4e95be17044ead0e1926b58cafc0d2cca9df3eb7a836234e886f3b51679f9',
+						remotes = {'ipv4 "vpn12.ffnord.net" port 10050', 'ipv6 "vpn12.ffnord.net" port 10050'},
+					},
 					ffnord_vpn13 = {
-            					key = '1eeabc7534bed144c30b6d62f9cefd2e0b54607ac4c2ac1343c5153bceb01ab1',
-            					remotes = {'ipv4 "vpn13.ffnord.net" port 10050', 'ipv6 "vpn13.ffnord.net" port 10050'},
-          				},
+						key = '1eeabc7534bed144c30b6d62f9cefd2e0b54607ac4c2ac1343c5153bceb01ab1',
+						remotes = {'ipv4 "vpn13.ffnord.net" port 10050', 'ipv6 "vpn13.ffnord.net" port 10050'},
+					},
 					ffnord_vpn14 = {
-            					key = '5c7930f1fc37ceca6c921c13bed8010e4bada7e422aa69ad195c24f92c12f679',
-            					remotes = {'ipv4 "vpn14.ffnord.net" port 10050', 'ipv6 "vpn14.ffnord.net" port 10050'},
-          				},
+						key = '5c7930f1fc37ceca6c921c13bed8010e4bada7e422aa69ad195c24f92c12f679',
+						remotes = {'ipv4 "vpn14.ffnord.net" port 10050', 'ipv6 "vpn14.ffnord.net" port 10050'},
+					},
 					ffnord_vpn15 = {
-            					key = 'ae5bfc856ffc779bd766619aa24242890539495bdac03bf28405e41ba087b9a8',
-            					remotes = {'ipv4 "vpn15.ffnord.net" port 10050', 'ipv6 "vpn15.ffnord.net" port 10050'},
-          				},
+						key = 'ae5bfc856ffc779bd766619aa24242890539495bdac03bf28405e41ba087b9a8',
+						remotes = {'ipv4 "vpn15.ffnord.net" port 10050', 'ipv6 "vpn15.ffnord.net" port 10050'},
+					},
 				},
 			},
 		},
 	},
 
 	bandwidth_limit = {
-  	enabled = false,
+		enabled = false,
 		egress = 800,
 		ingress = 4000,
 	},
@@ -177,7 +177,7 @@
 					'http://[2a03:2267:4e6f:7264::fd13]/firmware/stable/sysupgrade/',
 					'http://[2a03:2267:4e6f:7264::fd14]/firmware/stable/sysupgrade/',
 					'http://[2a03:2267:4e6f:7264::fd15]/firmware/stable/sysupgrade/',
-        },
+				},
 				good_signatures = 2,
 				pubkeys = {
 					'bbb814470889439c04667748c30aabf25fb800621e67544bee803fd1b342ace3', -- sargon
@@ -190,34 +190,34 @@
 				},
 			},
 			experimental = {
-      			name = 'experimental',
-			mirrors = {
-				'http://[2a03:2267:4e6f:7264::fd00]/firmware/experimental/sysupgrade/',
-				'http://[2a03:2267:4e6f:7264::fd02]/firmware/experimental/sysupgrade/',
-				'http://[2a03:2267:4e6f:7264::fd03]/firmware/experimental/sysupgrade/',
-				'http://[2a03:2267:4e6f:7264::fd04]/firmware/experimental/sysupgrade/',
-				'http://[2a03:2267:4e6f:7264::fd05]/firmware/experimental/sysupgrade/',
-				'http://[2a03:2267:4e6f:7264::fd06]/firmware/experimental/sysupgrade/',
-				'http://[2a03:2267:4e6f:7264::fd07]/firmware/experimental/sysupgrade/',
-				'http://[2a03:2267:4e6f:7264::fd08]/firmware/experimental/sysupgrade/',
-				'http://[2a03:2267:4e6f:7264::fd09]/firmware/experimental/sysupgrade/',
-				'http://[2a03:2267:4e6f:7264::fd10]/firmware/experimental/sysupgrade/',
-				'http://[2a03:2267:4e6f:7264::fd11]/firmware/experimental/sysupgrade/',
-				'http://[2a03:2267:4e6f:7264::fd12]/firmware/experimental/sysupgrade/',
-				'http://[2a03:2267:4e6f:7264::fd13]/firmware/experimental/sysupgrade/',
-				'http://[2a03:2267:4e6f:7264::fd14]/firmware/experimental/sysupgrade/',
-				'http://[2a03:2267:4e6f:7264::fd15]/firmware/experimental/sysupgrade/',
-      			},
-			probability = 0.1,
-			good_signatures = 1,
-			pubkeys = {
-				'bbb814470889439c04667748c30aabf25fb800621e67544bee803fd1b342ace3', -- sargon
-				'e46bcbb302a250d414d2f014fc55d179693cd39c6527d120924a1e985dd8ae5f', -- DO9XE
-				'bd5a70d4c3df30eaa860d615c0e0526b0dda5bc60c09c20972bce4ffa7512659', -- bjoern
-				'1d37eacbd70f72730b1f5aba246a6a8eab100e2d45dda0163d9ad827f70f88d4', -- gernot
-				'589695821488c9acd2efc26c2fdde259b25615cbfdbb6a434e95e33fa6932023', -- Tarnatos
-				'c83161964de2763ab2fc5730dcc0f8766212f130e6b48b3b42d7f1055c05a2be', -- bigfoot
-				'ce692fd4f662710aabe32ee629b37f594ac9f3876fb324cb1fc9aaf3090a7e6e', -- rubo77
+				name = 'experimental',
+				mirrors = {
+					'http://[2a03:2267:4e6f:7264::fd00]/firmware/experimental/sysupgrade/',
+					'http://[2a03:2267:4e6f:7264::fd02]/firmware/experimental/sysupgrade/',
+					'http://[2a03:2267:4e6f:7264::fd03]/firmware/experimental/sysupgrade/',
+					'http://[2a03:2267:4e6f:7264::fd04]/firmware/experimental/sysupgrade/',
+					'http://[2a03:2267:4e6f:7264::fd05]/firmware/experimental/sysupgrade/',
+					'http://[2a03:2267:4e6f:7264::fd06]/firmware/experimental/sysupgrade/',
+					'http://[2a03:2267:4e6f:7264::fd07]/firmware/experimental/sysupgrade/',
+					'http://[2a03:2267:4e6f:7264::fd08]/firmware/experimental/sysupgrade/',
+					'http://[2a03:2267:4e6f:7264::fd09]/firmware/experimental/sysupgrade/',
+					'http://[2a03:2267:4e6f:7264::fd10]/firmware/experimental/sysupgrade/',
+					'http://[2a03:2267:4e6f:7264::fd11]/firmware/experimental/sysupgrade/',
+					'http://[2a03:2267:4e6f:7264::fd12]/firmware/experimental/sysupgrade/',
+					'http://[2a03:2267:4e6f:7264::fd13]/firmware/experimental/sysupgrade/',
+					'http://[2a03:2267:4e6f:7264::fd14]/firmware/experimental/sysupgrade/',
+					'http://[2a03:2267:4e6f:7264::fd15]/firmware/experimental/sysupgrade/',
+				},
+				probability = 0.1,
+				good_signatures = 1,
+				pubkeys = {
+					'bbb814470889439c04667748c30aabf25fb800621e67544bee803fd1b342ace3', -- sargon
+					'e46bcbb302a250d414d2f014fc55d179693cd39c6527d120924a1e985dd8ae5f', -- DO9XE
+					'bd5a70d4c3df30eaa860d615c0e0526b0dda5bc60c09c20972bce4ffa7512659', -- bjoern
+					'1d37eacbd70f72730b1f5aba246a6a8eab100e2d45dda0163d9ad827f70f88d4', -- gernot
+					'589695821488c9acd2efc26c2fdde259b25615cbfdbb6a434e95e33fa6932023', -- Tarnatos
+					'c83161964de2763ab2fc5730dcc0f8766212f130e6b48b3b42d7f1055c05a2be', -- bigfoot
+					'ce692fd4f662710aabe32ee629b37f594ac9f3876fb324cb1fc9aaf3090a7e6e', -- rubo77
 				},
 			},
 			earlybird = {
@@ -249,9 +249,9 @@
 					'589695821488c9acd2efc26c2fdde259b25615cbfdbb6a434e95e33fa6932023', -- Tarnatos
 					'c83161964de2763ab2fc5730dcc0f8766212f130e6b48b3b42d7f1055c05a2be', -- bigfoot
 					'ce692fd4f662710aabe32ee629b37f594ac9f3876fb324cb1fc9aaf3090a7e6e', -- rubo77
-					},
 				},
-				ownbuild = {
+			},
+			ownbuild = {
 				name = 'ownbuild',
 				mirrors = {
 					'http://[2a03:2267:4e6f:7264::fd00]/firmware/ownbuild/sysupgrade/',

--- a/site.mk
+++ b/site.mk
@@ -20,7 +20,6 @@ GLUON_SITE_PACKAGES := \
 	gluon-mesh-vpn-fastd \
 	gluon-radvd \
 	gluon-status-page \
-#	gluon-au-change \
 	iwinfo \
 	fastd-traffic-status \
 	iptables \
@@ -49,26 +48,26 @@ USB_PACKAGES_BASIC := \
 	kmod-usb2
 # FAT32 Support for USB
 USB_PACKAGES := $(USB_PACKAGES_BASIC) \
-    block-mount \
-    kmod-fs-ext4 \
-    kmod-fs-vfat \
-    kmod-usb-storage  \
-    kmod-usb-storage-extras  \
-    blkid  \
-    swap-utils  \
-    kmod-nls-cp1250  \
-    kmod-nls-cp1251  \
-    kmod-nls-cp437  \
-    kmod-nls-cp775  \
-    kmod-nls-cp850  \
-    kmod-nls-cp852  \
-    kmod-nls-cp866  \
-    kmod-nls-iso8859-1  \
-    kmod-nls-iso8859-13  \
-    kmod-nls-iso8859-15  \
-    kmod-nls-iso8859-2  \
-    kmod-nls-koi8r  \
-    kmod-nls-utf8
+	block-mount \
+	kmod-fs-ext4 \
+	kmod-fs-vfat \
+	kmod-usb-storage  \
+	kmod-usb-storage-extras  \
+	blkid  \
+	swap-utils  \
+	kmod-nls-cp1250  \
+	kmod-nls-cp1251  \
+	kmod-nls-cp437  \
+	kmod-nls-cp775  \
+	kmod-nls-cp850  \
+	kmod-nls-cp852  \
+	kmod-nls-cp866  \
+	kmod-nls-iso8859-1  \
+	kmod-nls-iso8859-13  \
+	kmod-nls-iso8859-15  \
+	kmod-nls-iso8859-2  \
+	kmod-nls-koi8r  \
+	kmod-nls-utf8
 
 ifeq ($(GLUON_TARGET),x86-generic)
 	# support the USB stack on x86 devices


### PR DESCRIPTION
A line in the site.mk that was commented out destroyed the continuation
of the line afterwards, and the indentation in the site.conf was totally
screwed (wild mixture of tabs and spaces with wrong levels of
indentation everywhere in the autoupdater section)
