### PR TITLE
Remove sudo:required

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,14 @@
 language: bash
 
-sudo: true
-
-before_install:
-  - sudo apt-get -qq update
-  - sudo apt-get install lua5.1 luarocks
+addons:
+  apt:
+    packages:
+    - lua5.1
+    - luarocks
   
 install:
-  - sudo luarocks install lua-cjson
+  - eval $(luarocks path --bin)
+  - luarocks install --local lua-cjson
 
 script:
   - bash tests/validate_site.sh


### PR DESCRIPTION
Wie schon in https://forum.freifunk.net/t/travis-ci-support-zur-validierung-der-site-conf/15231/2?u=mtrnord vorgeschlagen braucht travis nicht sudo:required. diese pull entfernt die abhängigkeit von sudo:required und nutzt dadurch nicht deren legacy umgebung.